### PR TITLE
make URLs clickable and open in browser

### DIFF
--- a/app.html
+++ b/app.html
@@ -52,7 +52,7 @@
             <div class="code-copy-button tc phs pvs pvm-ns f4 btn w-100 mw-fill">Copy</div>
           </div>
         </div>
-        <p class="mbx">Send this code to the person you want to share your screen with. They can use ScreenCat.app or http://maxogden.github.io/screencat/remote in Google Chrome.</p>
+        <p class="mbx">Send this code to the person you want to share your screen with. They can use <a href="https://github.com/maxogden/screencat/releases/latest" class="open-externally">ScreenCat.app</a> or <a href="http://maxogden.github.io/screencat/remote" class="open-externally">http://maxogden.github.io/screencat/remote</a> in Google Chrome.</p>
       </div>
 
       <div class="join-container dn">

--- a/css/screencat.css
+++ b/css/screencat.css
@@ -20,3 +20,7 @@
 .content-container.w-50 {
   margin: auto;
 }
+
+a {
+  color: black;
+}

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var createApp = require('./create.js')
 
 var ipc = require('ipc')
 var clipboard = require('clipboard')
+var shell = require('shell')
 
 var app = createApp({}, function connected (peer, isRemote) {
   if (isRemote) ipc.send('resize', {width: 800, height: 500})
@@ -38,3 +39,12 @@ app.ui.buttons.copy.addEventListener('click', function (e) {
   e.preventDefault()
   clipboard.writeText(app.ui.inputs.copy.value)
 })
+
+var externalLinks = document.querySelectorAll('.open-externally')
+for (var i = 0; i < externalLinks.length; i++) {
+  externalLinks[i].onclick = function (e) {
+    e.preventDefault()
+    shell.openExternal(e.target.href)
+    return false
+  }
+}


### PR DESCRIPTION
hello fellow Max,

This is such a cool project. I don't totally understand how it all works but here's a small contribution if it makes sense :). Kind of inspired by [this example](https://github.com/atom/atom-shell/blob/b2b70bb37c05e98f8e3fb2282bad538bde7f4dff/atom/browser/default_app/index.html#L63-L68), not sure if there's a better way to make the links open in the user's preferred browser.

![screenshot 2015-03-27 19 35 00](https://cloud.githubusercontent.com/assets/1421211/6878663/6679b132-d4b8-11e4-9331-d5fb0d51dfcd.png)

(I'm not sure why it's not currently generating channel names for me)