### PR TITLE
fix back button

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ app.ui.buttons.back.addEventListener('click', function (e) {
   var el = app.ui.buttons.paste
   var elClone = el.cloneNode(true)
   el.parentNode.replaceChild(elClone, el)
+  app.ui.buttons.paste = elClone
 
   showChoose()
 })


### PR DESCRIPTION
the second time you hit the back button, the `app.ui.buttons.paste` reference is broken, due to this clone/swap hack, and `el.parentNode` is `null`